### PR TITLE
#256 - change redirect to newly stored vendor

### DIFF
--- a/app/Http/Controllers/VendorController.php
+++ b/app/Http/Controllers/VendorController.php
@@ -164,7 +164,7 @@ class VendorController extends Controller
             $url_twitter->website_type='Twitter';
         $url_twitter->save();
  
-        return Redirect::action('VendorController@index');
+        return Redirect::action('VendorController@show',$vendor->id);
     }
 
     /**


### PR DESCRIPTION
Jairo was confused when he started to add someone and then it went back to the index. I had generally taken folks back to the index but it makes sense to go the record that was just created. Jairo re-entered the information again and then discovered it was duplicated and didn't have the ability to delete so that added to the confusion. We may want to change this in other places so that the behavior is consistent and on storing a record we then see what was stored but for now we will start with vendor. Let me know what you think from a usability perspective.