### PR TITLE
When adding a donation for a contact only show retreats for which they are registered (fix #259)

### DIFF
--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -38,7 +38,7 @@ class DonationController extends Controller
         // dd($subcontact_type_id,$id);
         if ($id>0) {
             $donor = \App\Contact::findOrFail($id); // a lazy way to fail if no donor
-	    $donor_events = \App\Registration::whereContactId($id)->get();
+	        $donor_events = \App\Registration::whereContactId($id)->get();
             $donors = \App\Contact::whereId($id)->pluck('sort_name','id');
         } else {
             $donors = \App\Contact::whereContactType(config('polanco.contact_type.individual'))->orderBy('sort_name')->pluck('sort_name', 'id');
@@ -47,7 +47,7 @@ class DonationController extends Controller
             $donors = \App\Contact::whereSubcontactType($subcontact_type_id)->orderBy('sort_name')->pluck('sort_name', 'id');
         }
         if (isset($event_id)) {
-	    $retreats = \App\Retreat::findOrFail($event_id); // a lazy way to fail if unknown event_id
+	        $retreats = \App\Retreat::findOrFail($event_id); // a lazy way to fail if unknown event_id
             $retreats = \App\Retreat::select(\DB::raw('CONCAT(idnumber, "-", title, " (",DATE_FORMAT(start_date,"%m-%d-%Y"),")") as description'), 'id')->whereId($event_id)->pluck('description', 'id');
             
         } else {

--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -38,7 +38,7 @@ class DonationController extends Controller
         // dd($subcontact_type_id,$id);
         if ($id>0) {
             $donor = \App\Contact::findOrFail($id); // a lazy way to fail if no donor
-	    $donor_events = \App\Participant::whereContactId($id)->get();
+	    $donor_events = \App\Registration::whereContactId($id)->get();
             $donors = \App\Contact::whereId($id)->pluck('sort_name','id');
         } else {
             $donors = \App\Contact::whereContactType(config('polanco.contact_type.individual'))->orderBy('sort_name')->pluck('sort_name', 'id');
@@ -52,7 +52,7 @@ class DonationController extends Controller
             
         } else {
             # $retreats = \App\Retreat::select(\DB::raw('CONCAT(idnumber, "-", title, " (",DATE_FORMAT(start_date,"%m-%d-%Y"),")") as description'), 'id')->where("is_active", "=", 1)->orderBy('start_date')->pluck('description', 'id');
-            $retreats = \App\Participant::leftjoin('event','participant.event_id',"=",'event.id')->select(\DB::raw('CONCAT(event.idnumber, "-", event.title, " (",DATE_FORMAT(event.start_date,"%m-%d-%Y"),")") as description'), 'event.id')->whereContactId($id)->orderBy('event.start_date')->pluck('event.description', 'event.id');
+            $retreats = \App\Registration::leftjoin('event','participant.event_id',"=",'event.id')->select(\DB::raw('CONCAT(event.idnumber, "-", event.title, " (",DATE_FORMAT(event.start_date,"%m-%d-%Y"),")") as description'), 'event.id')->whereContactId($id)->orderBy('event.start_date','desc')->pluck('event.description', 'event.id');
             $retreats->prepend('Unassigned', 0);
         }
         

--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -38,6 +38,7 @@ class DonationController extends Controller
         // dd($subcontact_type_id,$id);
         if ($id>0) {
             $donor = \App\Contact::findOrFail($id); // a lazy way to fail if no donor
+	    $donor_events = \App\Participant::whereContactId($id)->get();
             $donors = \App\Contact::whereId($id)->pluck('sort_name','id');
         } else {
             $donors = \App\Contact::whereContactType(config('polanco.contact_type.individual'))->orderBy('sort_name')->pluck('sort_name', 'id');
@@ -46,11 +47,12 @@ class DonationController extends Controller
             $donors = \App\Contact::whereSubcontactType($subcontact_type_id)->orderBy('sort_name')->pluck('sort_name', 'id');
         }
         if (isset($event_id)) {
-            $retreats = \App\Retreat::findOrFail($event_id);
+	    $retreats = \App\Retreat::findOrFail($event_id); // a lazy way to fail if unknown event_id
             $retreats = \App\Retreat::select(\DB::raw('CONCAT(idnumber, "-", title, " (",DATE_FORMAT(start_date,"%m-%d-%Y"),")") as description'), 'id')->whereId($event_id)->pluck('description', 'id');
             
         } else {
-            $retreats = \App\Retreat::select(\DB::raw('CONCAT(idnumber, "-", title, " (",DATE_FORMAT(start_date,"%m-%d-%Y"),")") as description'), 'id')->where("end_date", ">", \Carbon\Carbon::today()->subWeek())->where("is_active", "=", 1)->orderBy('start_date')->pluck('description', 'id');
+            # $retreats = \App\Retreat::select(\DB::raw('CONCAT(idnumber, "-", title, " (",DATE_FORMAT(start_date,"%m-%d-%Y"),")") as description'), 'id')->where("is_active", "=", 1)->orderBy('start_date')->pluck('description', 'id');
+            $retreats = \App\Participant::leftjoin('event','participant.event_id',"=",'event.id')->select(\DB::raw('CONCAT(event.idnumber, "-", event.title, " (",DATE_FORMAT(event.start_date,"%m-%d-%Y"),")") as description'), 'event.id')->whereContactId($id)->orderBy('event.start_date')->pluck('event.description', 'event.id');
             $retreats->prepend('Unassigned', 0);
         }
         


### PR DESCRIPTION
This will help the finance office to handle donations that are older. It does not happen with a great deal of frequency but hopefully this will make it easier for them. 