### PR TITLE
add Scholarships, Buildings and Maintetance and Endowments to AGC list (fix 277)

### DIFF
--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -41,8 +41,8 @@ class DonationController extends Controller
         $prev_year = $year - 1;
 
         $this->authorize('show-donation');
-        $all_donations = \App\Donation::orderBy('donation_date', 'desc')->whereDonationDescription("Annual Giving")->where("donation_date", ">=", $prev_year."-07-01")->where("donation_date", "<", $year."-07-01")->with('contact')->get();
-        $donations = \App\Donation::orderBy('donation_date', 'desc')->whereDonationDescription("Annual Giving")->where("donation_date", ">=", $prev_year."-07-01")->where("donation_date", "<", $year."-07-01")->with('contact')->paginate(100);
+        $all_donations = \App\Donation::orderBy('donation_date', 'desc')->whereIn('donation_description',["Annual Giving","Endowment","Scholarship","Buildings & Maintenance"])->where("donation_date", ">=", $prev_year."-07-01")->where("donation_date", "<", $year."-07-01")->with('contact')->get();
+        $donations = \App\Donation::orderBy('donation_date', 'desc')->whereIn('donation_description',["Annual Giving","Endowment","Scholarship","Buildings & Maintenance"])->where("donation_date", ">=", $prev_year."-07-01")->where("donation_date", "<", $year."-07-01")->with('contact')->paginate(100);
         $total['pledged'] = $all_donations->sum('donation_amount');
         $total['paid'] = $all_donations->sum('payments_paid');
         if ($total['pledged'] > 0) {


### PR DESCRIPTION
I have tested this on production. The whole AGC giving is somewhat specific to Montserrat. From a coding and reusability perspective it would be better to all the various donation_descriptions to have an abbreviation and be able to look at them individually. Down the road, and mindful on how CiviCRM deals with subaccounts it would be good to have the ability to look at subaccounts. For now, this is sufficient and a feature that I am going to go ahead and merge into master so that we can get acknowledgement letters printed and mailed out.