### PR TITLE
#287 - quick option to show uncanceled registrations when view retreat (fix 287)

### DIFF
--- a/app/Http/Controllers/RetreatController.php
+++ b/app/Http/Controllers/RetreatController.php
@@ -164,11 +164,32 @@ class RetreatController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show($id, $status = NULL)
     {
         $this->authorize('show-retreat');
         $retreat = \App\Retreat::with('retreatmasters', 'innkeeper', 'assistant', 'captains')->findOrFail($id);
-        $registrations = \App\Registration::where('event_id', '=', $id)->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+
+        switch ($status) {
+            case 'active':
+                $registrations = \App\Registration::where('event_id', '=', $id)->whereNull('canceled_at')->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+                break;
+            case 'cancel':
+                $registrations = \App\Registration::where('event_id', '=', $id)->whereNotNull('canceled_at')->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+                break;
+            case 'confirm':
+                $registrations = \App\Registration::where('event_id', '=', $id)->whereNotNull('registration_confirm_date')->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+                break;
+            case 'arrive':
+                $registrations = \App\Registration::where('event_id', '=', $id)->whereNotNull('arrived_at')->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+                break;
+            case 'depart':
+                $registrations = \App\Registration::where('event_id', '=', $id)->whereNotNull('departed_at')->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+                break;
+            default:
+                $registrations = \App\Registration::where('event_id', '=', $id)->with('retreatant.parish')->orderBy('register_date', 'ASC')->get();
+                break;
+        }
+
         return view('retreats.show', compact('retreat', 'registrations'));//
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -206,6 +206,7 @@ Route::post('retreat/room_update', ['as' => 'retreat.room_update', 'uses' => 'Re
 Route::post('retreat/payments/update', ['as' => 'retreat.payments.update', 'uses' => 'DonationController@retreat_payments_update']);
 Route::get('retreat/{id}/checkout', ['as'=>'retreat.checkout','uses' => 'RetreatController@checkout']);
 Route::get('retreat/{id}/checkin', ['as'=>'retreat.checkin','uses' => 'RetreatController@checkin']);
+Route::get('retreat/{id}/status/{status}', ['as'=>'retreat.show','uses' => 'RetreatController@show']);
 
 Route::resource('retreat', 'RetreatController');
 


### PR DESCRIPTION
this will give an option to scope or limit the registrations seen - ideally I would like there to be a dropdown status indicator in the registrations section so that the user can select all, active, cancel, arrive, depart, confirm. There are certainly cleaner ways of implementing this but for now I want an easy way to compare the finance open deposits report (based on donations/payments) with the registrations that are shown as open deposits. 