### PR TITLE
initial attempt to send email to finance when the registration event_… (fix #295)

### DIFF
--- a/app/Mail/RegistrationEventChange.php
+++ b/app/Mail/RegistrationEventChange.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class RegistrationEventChange extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $registration;
+    public $retreat;
+    public $original_event;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($registration, $retreat, $original_event)
+    {
+        $this->registration = $registration;
+        $this->retreat = $retreat;
+        $this->original_event = $original_event;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {   
+        return $this->subject('Notification of Registration Update: Event changed')
+                    ->replyTo('registration@montserratretreat.org')
+                    ->view('emails.registration-event-change');
+    }
+}

--- a/config/polanco.php
+++ b/config/polanco.php
@@ -25,6 +25,8 @@ return [
 
     'admin_name' => 'Anthony Borrow',
     'admin_email' => 'anthony.borrow@montserratretreat.org',
+    'finance_email' => 'finance@montserratretreat.org',
+    'notify_registration_event_change' => '1',
 
     'relationship_type' => [
         'child_parent' => '1',

--- a/resources/views/emails/registration-event-change.blade.php
+++ b/resources/views/emails/registration-event-change.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+</head>
+<body>
+	<p>{{config('polanco.site_name')}} would like to notify you that <a href="{{URL('registration',$registration->id)}}">Registration #{{ $registration->id }}</a> for {!!$registration->retreatant->contact_link_full_name!!} has recently been updated as follows:</p>
+	<p>from - <a href="{{ URL('retreat',$original_event->id) }}">{{ $original_event->retreat_name }}</a> ({{ $original_event->idnumber }}) - {{$original_event->retreat_type}}</p>
+	<p>to - <a href="{{ URL('retreat',$retreat->id) }}">{{ $retreat->retreat_name }}</a> ({{ $retreat->idnumber }}) - {{$retreat->retreat_type}}</p>
+	<p>Kindly ensure that the appropriate changes are made to the financial history.
+</body>
+</html>


### PR DESCRIPTION
This should send an email to finance when the event_id is changed for a registration. If the email fails to send, the exception should be displayed and the change will not be saved. This is a bit of an ugly way to fail but it should get the attention of the person making the change. We can come back later and make a custom exception to ask the person to manually send the email. 